### PR TITLE
Update plugin.json to use staticDirs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -15,5 +15,5 @@
 			"hook": "filter:admin.create_routes", "method": "addAdminRoute", "callbacked": true
 		}
 	],
-	"staticDir": "./static"
+	"staticDirs": ["./static"]
 }


### PR DESCRIPTION
Update plugin.json to use staticDirs instead of staticDir, now deprecated
Hey, you look nice, dear error message `Error checking merge status`. Nice to meet you.
