### PR TITLE
Add OAuth.deleteUserData method

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
 	"library": "./library.js",
 	"hooks": [
 		{ "hook": "action:app.load", "method": "init" },
-		{ "hook": "action:user.delete", "method": "deleteUserData" },
+		{ "hook": "filter:user.delete", "method": "deleteUserData" },
 		{ "hook": "filter:auth.init", "method": "getStrategy" },
 		{ "hook": "filter:admin.header.build", "method": "addMenuItem" }
 	],


### PR DESCRIPTION
Removes the user's oAuthId-to-uid mapping from Redis upon user deletion.
This fixes an issue where OAuth services could not link to a user if a
user account was deleted and then re-created.
