### PR TITLE
Fix exporting of hooks

### DIFF
--- a/library.js
+++ b/library.js
@@ -64,7 +64,7 @@ const constants = Object.freeze({
 	userRoute: '', // This is the address to your app's "user profile" API endpoint (expects JSON)
 });
 
-const OAuth = {};
+const OAuth = module.exports;
 let configOk = false;
 let passportOAuth;
 let opts;


### PR DESCRIPTION
In the current state, the plugin does not load the webhooks.
`Expected method for hook 'static:app.load' in plugin 'nodebb-plugin-sso-oauth-faforever' not found, skipping.` (for each hook)
The solution is borrowed from the sso-oauth2-multiple plugin.